### PR TITLE
Fix title in Nested View Transitions Explainer

### DIFF
--- a/nested-explainer.md
+++ b/nested-explainer.md
@@ -1,4 +1,4 @@
-# Explainer: Nested View Transitions
+# Explainer: Nested View Transition Groups
 
 # Overview
 [view transitions](https://www.w3.org/TR/css-view-transitions-1/) work by generating a pseudo-element tree representing groups of the captured old state & the live new state of a transition.
@@ -16,7 +16,8 @@ some animations would look "broken" by default, e.g. elements abruptly lose thei
 
 The solution is based on two features. They are completely decoupled from each other, but work together to address the use case.
 
-## Nested view transitiions
+## Nested View Transition Groups
+
 Instead of a flat tree, the author can nest `::view-transition-group` pseudo-elements within each other.
 This is done with a new property, `view-transition-group`, which when applied on an element with a `view-transition-name`, defines whether the generated `::view-transition-group` gets nested in one of its containers,
 or it would nest its own participating descendants.

--- a/nested-explainer.md
+++ b/nested-explainer.md
@@ -1,4 +1,4 @@
-# Explainer: Nested View Transitions & Capture Modes
+# Explainer: Nested View Transitions
 
 # Overview
 [view transitions](https://www.w3.org/TR/css-view-transitions-1/) work by generating a pseudo-element tree representing groups of the captured old state & the live new state of a transition.

--- a/nested-explainer.md
+++ b/nested-explainer.md
@@ -12,9 +12,9 @@ This is sufficient for many use cases, but not for all. Some CSS features rely o
 When any of the above features is used, view transitions start to feel constrained. Apart from the fact that not all animation styles are possible,
 some animations would look "broken" by default, e.g. elements abruptly lose their clip for the duration of the transition.
 
-# Proposed solutions
+# Proposed solution
 
-The solution is based on two features. They are completely decoupled from each other, but work together to address the use case.
+The proposed solution is to allow authors to nest View Transtion Groups in order to recreate the original hierarchy from the original elements in the DOM.
 
 ## Nested View Transition Groups
 


### PR DESCRIPTION
The capture modes part got split off in https://github.com/WICG/view-transitions/commit/a5e05d6c3f20a8aa42c4540ebc2745b9542503f9 but the title was not updated to reflect this. This PR fixes that.

Additionally the feature got renamed to “Nested View Transition Groups”, which is also covered by this PR.